### PR TITLE
Ignore case in high zoom levels

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -138,7 +138,7 @@ function search() {
 
       function filterGeoJSON(feature, layer) {
         if (useNormalApi) {
-          return ids.indexOf(feature.properties.id) == -1 && feature.properties.comments[0].text.includes(query);
+          return ids.indexOf(feature.properties.id) == -1 && feature.properties.comments[0].text.toUpperCase().includes(query.toUpperCase());
         }
         return ids.indexOf(feature.properties.id) == -1;
       }


### PR DESCRIPTION

Not tested!
Fixes https://github.com/ENT8R/NotesReview/issues/6

See https://stackoverflow.com/questions/2140627/javascript-case-insensitive-string-compariso for other ways to do it. Maybe localeCompare might be the better (modern) way (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare), but huh...